### PR TITLE
fix(ci): bump Node heap limit for type-check job to 6GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint-and-typecheck:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=6144'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The Lint & Type Check job was failing with exit code 134 (SIGABRT) after the lockfile fix — tsc was running out of heap on the ~1,100 component frontend under Node's default max-old-space-size. The Build job already sets NODE_OPTIONS to 4GB; giving the type-check job 6GB leaves headroom on GitHub's 7GB ubuntu-latest runner.

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New tool component

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where applicable
- [ ] My changes don't introduce new warnings or errors
- [ ] I have tested this locally

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
