### PR TITLE
feat: add Ollama as local/offline LLM provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,19 +47,25 @@ API_PREFIX=api/v1
 FRONTEND_URL=http://localhost:5180
 
 # =====================================================
-# LLM CONFIGURATION (OpenRouter Unified Gateway)
+# LLM CONFIGURATION
 # =====================================================
 #
-# We use OpenRouter as the unified gateway for ALL LLM providers.
-# Benefits:
-# - Single API key for 500+ models (OpenAI, Anthropic, Google, DeepSeek, etc.)
-# - No $100 credit limit like direct Anthropic
-# - Same pricing as direct API (5.5% fee on credit purchase only)
-# - No rate limits for paid models
-# - Easy model switching without code changes
+# LLM_PROVIDER controls which backend handles LLM requests:
+#   openrouter (default) - Cloud gateway for 500+ models (OpenAI, Anthropic, Google, etc.)
+#   ollama               - Local/offline models via Ollama (privacy-first, no API keys needed)
+#   openai               - Direct OpenAI API
 #
 # Get your OpenRouter API key at: https://openrouter.ai/keys
 # =====================================================
+
+# LLM Provider: openrouter (default) | ollama | openai
+LLM_PROVIDER=openrouter
+
+# Ollama (local, fully offline — https://ollama.com)
+# Run `ollama serve` and `ollama pull llama3.2` to get started
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_MODEL=llama3.2
+OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 
 # OpenRouter API Key (PRIMARY - required for multi-model support)
 OPENROUTER_API_KEY=your_openrouter_api_key_here

--- a/backend/src/modules/ai/ai.service.ts
+++ b/backend/src/modules/ai/ai.service.ts
@@ -46,13 +46,25 @@ export class AiService {
     private creditsService: CreditsService,
     private dynamicConfig: DynamicLLMConfigService,
   ) {
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+    const llmProvider = this.configService.get<string>('LLM_PROVIDER', 'openrouter');
 
-    if (apiKey) {
-      this.openai = new OpenAI({ apiKey, timeout: 120000 });
-      this.logger.log('✅ OpenAI client initialized');
+    if (llmProvider === 'ollama') {
+      // Ollama: create an OpenAI-compatible client pointed at the local server
+      const ollamaBaseUrl = this.configService.get<string>('OLLAMA_BASE_URL', 'http://localhost:11434/v1');
+      this.openai = new OpenAI({
+        apiKey: 'ollama', // Dummy key — required by SDK but unused by Ollama
+        baseURL: ollamaBaseUrl,
+        timeout: 120000,
+      });
+      this.logger.log(`Ollama client initialized for embeddings (${ollamaBaseUrl})`);
     } else {
-      this.logger.warn('OPENAI_API_KEY not configured - AI features disabled');
+      const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+      if (apiKey) {
+        this.openai = new OpenAI({ apiKey, timeout: 120000 });
+        this.logger.log('OpenAI client initialized');
+      } else {
+        this.logger.warn('OPENAI_API_KEY not configured - AI features disabled');
+      }
     }
 
     this.defaultModel = this.configService.get<string>('OPENAI_MODEL', 'gpt-4o-mini');
@@ -81,8 +93,13 @@ export class AiService {
     }
 
     try {
+      // Use Ollama embedding model when provider is ollama
+      const model = this.llmRouter.getLLMProvider() === 'ollama'
+        ? this.llmRouter.getOllamaEmbeddingModel()
+        : this.embeddingModel;
+
       const response = await this.openai.embeddings.create({
-        model: this.embeddingModel,
+        model,
         input: texts,
       });
 

--- a/backend/src/modules/ai/llm/llm-router.service.ts
+++ b/backend/src/modules/ai/llm/llm-router.service.ts
@@ -99,10 +99,24 @@ export class LLMRouterService implements OnModuleInit {
   // Direct OpenAI client (fallback only)
   private openaiClient: OpenAI | null = null;
 
+  // Ollama client (local/offline)
+  private ollamaClient: OpenAI | null = null;
+
+  // Active LLM provider: 'openrouter' | 'ollama' | 'openai'
+  private llmProvider: string;
+
+  // Ollama model overrides
+  private ollamaModel: string;
+  private ollamaEmbeddingModel: string;
+
   constructor(
     private configService: ConfigService,
     private dynamicConfig: DynamicLLMConfigService,
-  ) {}
+  ) {
+    this.llmProvider = this.configService.get<string>('LLM_PROVIDER', 'openrouter');
+    this.ollamaModel = this.configService.get<string>('OLLAMA_MODEL', 'llama3.2');
+    this.ollamaEmbeddingModel = this.configService.get<string>('OLLAMA_EMBEDDING_MODEL', 'nomic-embed-text');
+  }
 
   async onModuleInit() {
     // Initialize clients in background to not block app startup
@@ -115,6 +129,22 @@ export class LLMRouterService implements OnModuleInit {
    * Initialize API clients
    */
   private async initializeClients() {
+    // Initialize Ollama if selected as provider
+    if (this.llmProvider === 'ollama') {
+      const ollamaBaseUrl = this.configService.get<string>('OLLAMA_BASE_URL', 'http://localhost:11434/v1');
+      this.ollamaClient = new OpenAI({
+        apiKey: 'ollama', // Dummy key — required by SDK but unused by Ollama
+        baseURL: ollamaBaseUrl,
+        timeout: 120000,
+      });
+      this.logger.log(`Ollama client initialized (${ollamaBaseUrl}, model: ${this.ollamaModel})`);
+
+      // Log available models
+      const models = this.dynamicConfig.getAllModels();
+      this.logger.log(`Available models: ${models.length}`);
+      return; // Skip cloud client init when running locally
+    }
+
     // Initialize OpenRouter (PRIMARY gateway for all models)
     const openRouterApiKey = this.configService.get<string>('OPENROUTER_API_KEY');
     if (openRouterApiKey) {
@@ -156,7 +186,7 @@ export class LLMRouterService implements OnModuleInit {
    * Check if the service is configured
    */
   isConfigured(): boolean {
-    return this.openRouterClient !== null || this.openaiClient !== null;
+    return this.ollamaClient !== null || this.openRouterClient !== null || this.openaiClient !== null;
   }
 
   /**
@@ -164,6 +194,9 @@ export class LLMRouterService implements OnModuleInit {
    */
   getAvailableProviders(): string[] {
     const providers: string[] = [];
+    if (this.ollamaClient) {
+      providers.push('ollama');
+    }
     if (this.openRouterClient) {
       // OpenRouter provides access to all providers
       providers.push('openrouter', 'openai', 'anthropic', 'google', 'deepseek');
@@ -171,6 +204,27 @@ export class LLMRouterService implements OnModuleInit {
       providers.push('openai');
     }
     return providers;
+  }
+
+  /**
+   * Get the active LLM provider
+   */
+  getLLMProvider(): string {
+    return this.llmProvider;
+  }
+
+  /**
+   * Get the Ollama model name (for callers that need to override model IDs)
+   */
+  getOllamaModel(): string {
+    return this.ollamaModel;
+  }
+
+  /**
+   * Get the Ollama embedding model name
+   */
+  getOllamaEmbeddingModel(): string {
+    return this.ollamaEmbeddingModel;
   }
 
   /**
@@ -198,6 +252,7 @@ export class LLMRouterService implements OnModuleInit {
    * Check if provider is available
    */
   isProviderAvailable(provider: string): boolean {
+    if (this.ollamaClient && provider === 'ollama') return true;
     if (this.openRouterClient) return true; // OpenRouter provides all
     if (this.openaiClient && provider === 'openai') return true;
     return false;
@@ -268,8 +323,11 @@ export class LLMRouterService implements OnModuleInit {
         };
       });
 
+      // Resolve model ID for the active provider (Ollama overrides to local model)
+      const resolvedModel = this.resolveModelId(modelId);
+
       const requestOptions: any = {
-        model: modelId,
+        model: resolvedModel,
         messages: formattedMessages,
         temperature: options.temperature ?? 0.7,
         max_tokens: options.maxTokens ?? modelConfig.maxOutput,
@@ -401,8 +459,8 @@ export class LLMRouterService implements OnModuleInit {
       );
     }
 
-    // Fall back to non-streaming if model doesn't support it
-    if (!modelConfig.supportsStreaming) {
+    // Fall back to non-streaming if model doesn't support it (Ollama always streams)
+    if (!modelConfig.supportsStreaming && this.llmProvider !== 'ollama') {
       const response = await this.chat(messages, options);
       yield {
         content: response.content,
@@ -421,18 +479,32 @@ export class LLMRouterService implements OnModuleInit {
     }
 
     try {
-      const stream = await client.chat.completions.create({
-        model: modelId,
-        messages: messages.map(m => ({
-          role: m.role,
-          content: m.content,
-          ...(m.name && { name: m.name }),
-        })),
-        temperature: options.temperature ?? 0.7,
-        max_tokens: options.maxTokens ?? modelConfig.maxOutput,
-        stream: true,
-        stream_options: { include_usage: true },
-      });
+      // Resolve model ID for the active provider
+      const resolvedModel = this.resolveModelId(modelId);
+
+      const baseMessages = messages.map(m => ({
+        role: m.role,
+        content: m.content,
+        ...(m.name && { name: m.name }),
+      }));
+
+      // Ollama may not support stream_options; omit it for ollama
+      const stream = this.llmProvider === 'ollama'
+        ? await client.chat.completions.create({
+            model: resolvedModel,
+            messages: baseMessages,
+            temperature: options.temperature ?? 0.7,
+            max_tokens: options.maxTokens ?? modelConfig.maxOutput,
+            stream: true,
+          })
+        : await client.chat.completions.create({
+            model: resolvedModel,
+            messages: baseMessages,
+            temperature: options.temperature ?? 0.7,
+            max_tokens: options.maxTokens ?? modelConfig.maxOutput,
+            stream: true,
+            stream_options: { include_usage: true },
+          });
 
       for await (const chunk of stream) {
         const delta = chunk.choices[0]?.delta?.content || '';
@@ -478,6 +550,11 @@ export class LLMRouterService implements OnModuleInit {
    * OpenRouter is the primary gateway for ALL models
    */
   private getClientForModel(modelId: string): OpenAI | null {
+    // Ollama: local/offline provider
+    if (this.ollamaClient && this.llmProvider === 'ollama') {
+      return this.ollamaClient;
+    }
+
     // Primary: Use OpenRouter for everything (unified gateway)
     if (this.openRouterClient) {
       return this.openRouterClient;
@@ -489,6 +566,18 @@ export class LLMRouterService implements OnModuleInit {
     }
 
     return null;
+  }
+
+  /**
+   * Resolve the actual model ID to send to the provider.
+   * When Ollama is active, any OpenRouter-style model ID (e.g. "openai/gpt-4o")
+   * is replaced with the configured OLLAMA_MODEL.
+   */
+  resolveModelId(modelId: string): string {
+    if (this.llmProvider === 'ollama') {
+      return this.ollamaModel;
+    }
+    return modelId;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `LLM_PROVIDER` env var (`openrouter` | `ollama` | `openai`) to select the LLM backend
- When `LLM_PROVIDER=ollama`, creates OpenAI SDK clients pointed at Ollama's OpenAI-compatible API (`http://localhost:11434/v1`) with a dummy API key
- Overrides all model name routing: OpenRouter-style IDs (e.g. `openai/gpt-4o`) are replaced with the configured `OLLAMA_MODEL` (e.g. `llama3.2`)
- Embeddings route through `OLLAMA_EMBEDDING_MODEL` (e.g. `nomic-embed-text`) when Ollama is active
- Default remains `openrouter` — zero changes for existing users

## How to use

```bash
# .env
LLM_PROVIDER=ollama
OLLAMA_BASE_URL=http://localhost:11434/v1
OLLAMA_MODEL=llama3.2
OLLAMA_EMBEDDING_MODEL=nomic-embed-text
```

```bash
ollama serve
ollama pull llama3.2
ollama pull nomic-embed-text
```

## Test plan

- [ ] `cd backend && npx tsc --noEmit` passes with 0 errors
- [ ] Existing OpenRouter flow works when `LLM_PROVIDER` is unset or `openrouter`
- [ ] With `LLM_PROVIDER=ollama` and Ollama running, chat completions succeed using local model
- [ ] Streaming works with Ollama provider
- [ ] Embeddings use `nomic-embed-text` when Ollama is active

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)