### PR TITLE
feat: file upload with analysis for chat context

### DIFF
--- a/backend/src/modules/chat/chat-file.service.ts
+++ b/backend/src/modules/chat/chat-file.service.ts
@@ -177,7 +177,7 @@ export class ChatFileService {
       if (lines.length === 0) return '[Empty CSV]';
 
       const header = lines[0];
-      const columns = header.split(',').map((c) => c.trim());
+      const columns = this.parseCsvRow(header);
       const previewRows = lines.slice(1, 11); // first 10 data rows
 
       let summary = `CSV file with ${columns.length} columns and ${lines.length - 1} rows.\n`;
@@ -236,6 +236,34 @@ export class ChatFileService {
       this.logger.warn('Image description failed:', error.message);
       return `[Image: ${file.originalname} - could not generate description]`;
     }
+  }
+
+  private parseCsvRow(row: string): string[] {
+    const result: string[] = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < row.length; i++) {
+      const ch = row[i];
+      if (inQuotes) {
+        if (ch === '"' && row[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else if (ch === '"') {
+          inQuotes = false;
+        } else {
+          current += ch;
+        }
+      } else if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ',') {
+        result.push(current.trim());
+        current = '';
+      } else {
+        current += ch;
+      }
+    }
+    result.push(current.trim());
+    return result;
   }
 
   private formatSize(bytes: number): string {

--- a/backend/src/modules/chat/chat-file.service.ts
+++ b/backend/src/modules/chat/chat-file.service.ts
@@ -1,0 +1,246 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DatabaseService } from '../database/database.service';
+import { R2Service } from '../storage/r2.service';
+import OpenAI from 'openai';
+
+export interface ChatFileUpload {
+  id: string;
+  user_id: string;
+  conversation_id: string;
+  filename: string;
+  file_type: string;
+  file_size: number;
+  extracted_text: string;
+  storage_path: string;
+  created_at: Date;
+}
+
+const SUPPORTED_TYPES = {
+  pdf: ['application/pdf'],
+  csv: ['text/csv', 'application/vnd.ms-excel'],
+  image: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp'],
+  text: [
+    'text/plain',
+    'text/markdown',
+    'application/json',
+    'text/html',
+    'text/css',
+    'text/javascript',
+    'application/javascript',
+  ],
+};
+
+@Injectable()
+export class ChatFileService {
+  private readonly logger = new Logger(ChatFileService.name);
+  private openai: OpenAI | null = null;
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly r2Service: R2Service,
+    private readonly configService: ConfigService,
+  ) {
+    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+    if (apiKey) {
+      this.openai = new OpenAI({ apiKey });
+    }
+  }
+
+  /**
+   * Upload a file, extract its text content, store in R2, and save metadata.
+   */
+  async uploadAndExtract(
+    userId: string,
+    conversationId: string,
+    file: Express.Multer.File,
+  ): Promise<ChatFileUpload> {
+    this.validateFile(file);
+
+    // Extract text content based on file type
+    const extractedText = await this.extractText(file);
+
+    // Upload to R2 storage
+    const uploadResult = await this.r2Service.uploadFile(file, userId, {
+      path: `chat-files/${conversationId}`,
+      isPublic: false,
+    });
+
+    // Store metadata in database
+    const chatFile = await this.db.insert<ChatFileUpload>('chat_file_uploads', {
+      user_id: userId,
+      conversation_id: conversationId,
+      filename: file.originalname,
+      file_type: file.mimetype,
+      file_size: file.size,
+      extracted_text: extractedText,
+      storage_path: uploadResult.key,
+      created_at: new Date(),
+    });
+
+    this.logger.log(
+      `File uploaded: ${file.originalname} (${file.size} bytes) for conversation ${conversationId}`,
+    );
+
+    return chatFile;
+  }
+
+  /**
+   * List all files uploaded to a specific conversation.
+   */
+  async listFiles(
+    conversationId: string,
+    userId: string,
+  ): Promise<ChatFileUpload[]> {
+    return this.db.findMany<ChatFileUpload>(
+      'chat_file_uploads',
+      { conversation_id: conversationId, user_id: userId },
+      { orderBy: 'created_at', order: 'DESC' },
+    );
+  }
+
+  /**
+   * Build a context string from an uploaded file for the AI.
+   */
+  buildFileContext(file: ChatFileUpload): string {
+    const truncated =
+      file.extracted_text.length > 50000
+        ? file.extracted_text.substring(0, 50000) + '\n... (content truncated)'
+        : file.extracted_text;
+    return `The user uploaded "${file.filename}" (${this.formatSize(file.file_size)}). Contents:\n${truncated}`;
+  }
+
+  // ============================================
+  // Private helpers
+  // ============================================
+
+  private validateFile(file: Express.Multer.File): void {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+
+    const maxSize = 20 * 1024 * 1024; // 20MB
+    if (file.size > maxSize) {
+      throw new BadRequestException('File size exceeds 20MB limit');
+    }
+
+    const allSupported = Object.values(SUPPORTED_TYPES).flat();
+    if (!allSupported.includes(file.mimetype)) {
+      throw new BadRequestException(
+        `Unsupported file type: ${file.mimetype}. Supported: PDF, CSV, images (PNG/JPEG/GIF/WebP), and text files.`,
+      );
+    }
+  }
+
+  private async extractText(file: Express.Multer.File): Promise<string> {
+    const { mimetype, buffer } = file;
+
+    if (SUPPORTED_TYPES.pdf.includes(mimetype)) {
+      return this.extractPdfText(buffer);
+    }
+
+    if (SUPPORTED_TYPES.csv.includes(mimetype)) {
+      return this.extractCsvText(buffer);
+    }
+
+    if (SUPPORTED_TYPES.image.includes(mimetype)) {
+      return this.extractImageDescription(file);
+    }
+
+    if (SUPPORTED_TYPES.text.includes(mimetype)) {
+      return buffer.toString('utf-8');
+    }
+
+    return `[Binary file: ${file.originalname}]`;
+  }
+
+  private async extractPdfText(buffer: Buffer): Promise<string> {
+    try {
+      const pdfParse = await import('pdf-parse');
+      const data = await pdfParse.default(buffer);
+      return data.text || '[Empty PDF]';
+    } catch (error) {
+      this.logger.warn('PDF extraction failed:', error.message);
+      return '[Could not extract PDF text]';
+    }
+  }
+
+  private extractCsvText(buffer: Buffer): string {
+    try {
+      const text = buffer.toString('utf-8');
+      const lines = text.split('\n').filter((l) => l.trim());
+
+      if (lines.length === 0) return '[Empty CSV]';
+
+      const header = lines[0];
+      const columns = header.split(',').map((c) => c.trim());
+      const previewRows = lines.slice(1, 11); // first 10 data rows
+
+      let summary = `CSV file with ${columns.length} columns and ${lines.length - 1} rows.\n`;
+      summary += `Columns: ${columns.join(', ')}\n\n`;
+      summary += `First ${Math.min(previewRows.length, 10)} rows:\n`;
+      summary += header + '\n';
+      summary += previewRows.join('\n');
+
+      if (lines.length > 11) {
+        summary += `\n... (${lines.length - 11} more rows)`;
+      }
+
+      return summary;
+    } catch (error) {
+      this.logger.warn('CSV extraction failed:', error.message);
+      return '[Could not parse CSV]';
+    }
+  }
+
+  private async extractImageDescription(
+    file: Express.Multer.File,
+  ): Promise<string> {
+    if (!this.openai) {
+      return `[Image: ${file.originalname} - AI vision not configured]`;
+    }
+
+    try {
+      const base64 = file.buffer.toString('base64');
+      const dataUrl = `data:${file.mimetype};base64,${base64}`;
+
+      const response = await this.openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Describe this image in detail. Include any text, data, charts, or key visual elements.',
+              },
+              {
+                type: 'image_url',
+                image_url: { url: dataUrl },
+              },
+            ],
+          },
+        ],
+        max_tokens: 1000,
+      });
+
+      return (
+        response.choices[0]?.message?.content ||
+        `[Image: ${file.originalname}]`
+      );
+    } catch (error) {
+      this.logger.warn('Image description failed:', error.message);
+      return `[Image: ${file.originalname} - could not generate description]`;
+    }
+  }
+
+  private formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+}

--- a/backend/src/modules/chat/chat.controller.ts
+++ b/backend/src/modules/chat/chat.controller.ts
@@ -12,17 +12,23 @@ import {
   Res,
   HttpCode,
   HttpStatus,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiBearerAuth,
   ApiQuery,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
 import { IsOptional, IsString, IsBoolean } from 'class-validator';
 import { Response } from 'express';
 import { ChatService } from './chat.service';
+import { ChatFileService } from './chat-file.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 class CreateConversationDto {
@@ -67,7 +73,10 @@ class SendMessageDto {
 @UseGuards(JwtAuthGuard)
 @Controller('chat')
 export class ChatController {
-  constructor(private readonly chatService: ChatService) {}
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly chatFileService: ChatFileService,
+  ) {}
 
   // ============================================
   // Conversations
@@ -213,6 +222,59 @@ export class ChatController {
   @ApiResponse({ status: 201, description: 'Conversation created and message sent' })
   async quickChat(@Request() req, @Body() dto: SendMessageDto) {
     return this.chatService.quickChat(req.user.sub, dto.content, dto.model);
+  }
+
+  // ============================================
+  // File Upload
+  // ============================================
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file', 'conversationId'],
+      properties: {
+        file: { type: 'string', format: 'binary' },
+        conversationId: { type: 'string' },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Upload a file for chat context' })
+  @ApiResponse({ status: 201, description: 'File uploaded and text extracted' })
+  @ApiResponse({ status: 400, description: 'Invalid file or missing conversation ID' })
+  async uploadFile(
+    @Request() req,
+    @UploadedFile() file: Express.Multer.File,
+    @Body('conversationId') conversationId: string,
+  ) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+
+    if (!conversationId) {
+      throw new Error('conversationId is required');
+    }
+
+    // Verify conversation ownership
+    await this.chatService.getConversation(conversationId, userId);
+
+    return this.chatFileService.uploadAndExtract(userId, conversationId, file);
+  }
+
+  @Get('files/:conversationId')
+  @ApiOperation({ summary: 'List files uploaded in a conversation' })
+  @ApiResponse({ status: 200, description: 'Files listed' })
+  @ApiResponse({ status: 404, description: 'Conversation not found' })
+  async listFiles(
+    @Request() req,
+    @Param('conversationId') conversationId: string,
+  ) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+
+    // Verify conversation ownership
+    await this.chatService.getConversation(conversationId, userId);
+
+    return this.chatFileService.listFiles(conversationId, userId);
   }
 
   // ============================================

--- a/backend/src/modules/chat/chat.controller.ts
+++ b/backend/src/modules/chat/chat.controller.ts
@@ -14,6 +14,7 @@ import {
   HttpStatus,
   UploadedFile,
   UseInterceptors,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -66,6 +67,10 @@ class SendMessageDto {
   @IsOptional()
   @IsString()
   model?: string;
+
+  @IsOptional()
+  @IsString()
+  fileContext?: string;
 }
 
 @ApiTags('Chat')
@@ -176,7 +181,7 @@ export class ChatController {
     @Param('id') id: string,
     @Body() dto: SendMessageDto,
   ) {
-    return this.chatService.sendMessage(id, req.user.sub, dto.content, dto.model);
+    return this.chatService.sendMessage(id, req.user.sub, dto.content, dto.model, dto.fileContext);
   }
 
   @Post('conversations/:id/messages/stream')
@@ -252,13 +257,14 @@ export class ChatController {
     const userId = req.user.userId || req.user.id || req.user.sub;
 
     if (!conversationId) {
-      throw new Error('conversationId is required');
+      throw new BadRequestException('conversationId is required');
     }
 
     // Verify conversation ownership
     await this.chatService.getConversation(conversationId, userId);
 
-    return this.chatFileService.uploadAndExtract(userId, conversationId, file);
+    const chatFile = await this.chatFileService.uploadAndExtract(userId, conversationId, file);
+    return this.transformFile(chatFile);
   }
 
   @Get('files/:conversationId')
@@ -274,7 +280,23 @@ export class ChatController {
     // Verify conversation ownership
     await this.chatService.getConversation(conversationId, userId);
 
-    return this.chatFileService.listFiles(conversationId, userId);
+    const files = await this.chatFileService.listFiles(conversationId, userId);
+    return files.map((f) => this.transformFile(f));
+  }
+
+  private transformFile(file: any) {
+    if (!file) return null;
+    return {
+      id: file.id,
+      userId: file.user_id,
+      conversationId: file.conversation_id,
+      filename: file.filename,
+      fileType: file.file_type,
+      fileSize: file.file_size,
+      extractedText: file.extracted_text,
+      storagePath: file.storage_path,
+      createdAt: file.created_at,
+    };
   }
 
   // ============================================

--- a/backend/src/modules/chat/chat.module.ts
+++ b/backend/src/modules/chat/chat.module.ts
@@ -1,12 +1,15 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { MulterModule } from '@nestjs/platform-express';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
+import { ChatFileService } from './chat-file.service';
 import { ChatGateway } from './chat.gateway';
 import { AuthModule } from '../auth/auth.module';
 import { IntentModule } from '../intent/intent.module';
 import { AiModule } from '../ai/ai.module';
 import { ContextModule } from '../context/context.module';
 import { MemoryModule } from '../memory/memory.module';
+import { StorageModule } from '../storage/storage.module';
 // AppMakerModule was excluded from the open-source release. The chat module
 // no longer depends on it; the app-builder branch in chat.gateway.ts is stubbed.
 // import { AppMakerModule } from '../app-maker/app-maker.module';
@@ -22,6 +25,10 @@ import { DataAnalysisModule } from '../data-analysis/data-analysis.module';
     forwardRef(() => AiModule),
     forwardRef(() => ContextModule),
     MemoryModule,
+    StorageModule,
+    MulterModule.register({
+      limits: { fileSize: 20 * 1024 * 1024 }, // 20MB
+    }),
     // AppMakerModule excluded from open-source release
     AppBuilderModule, // For DeploymentService
     AppFilesModule,
@@ -29,7 +36,7 @@ import { DataAnalysisModule } from '../data-analysis/data-analysis.module';
     forwardRef(() => DataAnalysisModule),
   ],
   controllers: [ChatController],
-  providers: [ChatService, ChatGateway],
-  exports: [ChatService, ChatGateway],
+  providers: [ChatService, ChatFileService, ChatGateway],
+  exports: [ChatService, ChatFileService, ChatGateway],
 })
 export class ChatModule {}

--- a/backend/src/modules/chat/chat.service.ts
+++ b/backend/src/modules/chat/chat.service.ts
@@ -190,6 +190,7 @@ export class ChatService {
     userId: string,
     content: string,
     model?: string,
+    fileContext?: string,
   ): Promise<{ userMessage: Message; assistantMessage: Message }> {
     if (!this.openai) {
       throw new BadRequestException('OpenAI is not configured');
@@ -202,6 +203,9 @@ export class ChatService {
     // Get conversation history
     const history = await this.getMessages(conversationId, userId, { limit: 50 });
 
+    // Build the full user content including any file context
+    const fullContent = fileContext ? `${fileContext}\n\nUser message: ${content}` : content;
+
     // Save user message
     const userMessage = await this.db.insert<Message>('messages', {
       conversation_id: conversationId,
@@ -209,7 +213,7 @@ export class ChatService {
       role: 'user',
       content,
       model: chatModel,
-      metadata: {},
+      metadata: fileContext ? { hasFileContext: true } : {},
       created_at: new Date(),
     });
 
@@ -224,7 +228,7 @@ export class ChatService {
           role: m.role as 'user' | 'assistant' | 'system',
           content: m.content,
         })),
-        { role: 'user', content },
+        { role: 'user', content: fullContent },
       ];
 
       // Call OpenAI

--- a/backend/src/modules/chat/index.ts
+++ b/backend/src/modules/chat/index.ts
@@ -1,3 +1,4 @@
 export * from './chat.module';
 export * from './chat.service';
+export * from './chat-file.service';
 export * from './chat.controller';

--- a/backend/src/modules/database/database.service.ts
+++ b/backend/src/modules/database/database.service.ts
@@ -257,6 +257,24 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
       await this.query(`CREATE INDEX IF NOT EXISTS idx_app_maker_pages_user_id ON app_maker_pages(user_id)`);
       await this.query(`CREATE INDEX IF NOT EXISTS idx_app_maker_pages_created_at ON app_maker_pages(created_at DESC)`);
 
+      // Chat file uploads table
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS chat_file_uploads (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id VARCHAR(255) NOT NULL,
+          conversation_id UUID NOT NULL,
+          filename VARCHAR(500) NOT NULL,
+          file_type VARCHAR(100) NOT NULL,
+          file_size INTEGER NOT NULL,
+          extracted_text TEXT,
+          storage_path TEXT NOT NULL,
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+      `);
+
+      await this.query(`CREATE INDEX IF NOT EXISTS idx_chat_file_uploads_conversation ON chat_file_uploads(conversation_id)`);
+      await this.query(`CREATE INDEX IF NOT EXISTS idx_chat_file_uploads_user ON chat_file_uploads(user_id)`);
+
       this.logger.log('✅ All required database tables ready');
     } catch (error) {
       this.logger.warn(`Failed to ensure required tables: ${error.message}`);


### PR DESCRIPTION
## Summary
- Add `ChatFileService` with `uploadAndExtract()` supporting PDF (pdf-parse), CSV (column summary + first 10 rows), images (GPT-4o-mini vision), and text/markdown files
- Add `POST /api/v1/chat/upload` (multipart, authed) and `GET /api/v1/chat/files/:conversationId` endpoints
- Store files in R2 via existing storage module, save extracted text + metadata in `chat_file_uploads` table (auto-created on startup)
- Extend `sendMessage` with optional `fileContext` parameter so extracted text can be included in AI context

Closes #48

## Test plan
- [ ] Upload a PDF and verify text extraction returns content
- [ ] Upload a CSV and verify column summary + first 10 rows returned
- [ ] Upload an image and verify AI-generated description
- [ ] Upload a .txt/.md and verify raw content returned
- [ ] Verify `GET /api/v1/chat/files/:conversationId` lists uploaded files
- [ ] Verify `npx tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)