### PR TITLE
feat: generative UI for dynamic tool creation

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -42,6 +42,7 @@ import { AppBuilderModule } from './modules/app-builder/app-builder.module';
 // import { AppMakerModule } from './modules/app-maker/app-maker.module';
 import { ToolsApiModule } from './modules/tools-api/tools-api.module';
 import { ToolsModule } from './modules/tools/tools.module';
+import { GenerativeUiModule } from './modules/generative-ui/generative-ui.module';
 
 @Module({
   imports: [
@@ -93,6 +94,7 @@ import { ToolsModule } from './modules/tools/tools.module';
     // AppMakerModule excluded from open-source release
     ToolsApiModule,
     ToolsModule,
+    GenerativeUiModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/chat/chat.gateway.ts
+++ b/backend/src/modules/chat/chat.gateway.ts
@@ -34,6 +34,7 @@ import { MemoryService } from '../memory/memory.service';
 // import { AppMakerService } from '../app-maker/app-maker.service';
 import { DeploymentService } from '../app-builder/services/deployment.service';
 import { AppFilesService } from '../app-files/app-files.service';
+import { GenerativeUiService } from '../generative-ui/generative-ui.service';
 
 interface AuthContext {
   userId: string;
@@ -139,6 +140,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     private readonly queryEngineAgent: QueryEngineAgent,
     private readonly chartBuilderAgent: ChartBuilderAgent,
     private readonly financeAnalyzerAgent: FinanceAnalyzerAgent,
+    private readonly generativeUiService: GenerativeUiService,
   ) {
     this.logger.log('ChatGateway initialized with namespace: /chat');
   }
@@ -991,6 +993,37 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
       // Fallback to AI - either no match or fallbackToAI was set
       if (!intentResult.intent.matched || intentResult.intent.fallbackToAI) {
+        // Check if we should generate a custom UI instead of a plain AI response
+        if (!assistantResponse && this.generativeUiService.shouldGenerateUi(message, intentResult.intent.confidence)) {
+          try {
+            this.logger.log(`Attempting generative UI for: "${message.substring(0, 50)}..."`);
+            const generatedUi = await this.generativeUiService.generateUi(
+              session.userId,
+              message,
+              { conversationId: session.conversationId },
+            );
+
+            // Emit the generated UI to the client
+            this.server.to(`session:${session.id}`).emit('generative-ui:created', {
+              sessionId: session.id,
+              html: generatedUi.html,
+              title: generatedUi.title,
+              description: generatedUi.description,
+              timestamp: new Date().toISOString(),
+            });
+
+            responseMetadata.generativeUi = {
+              title: generatedUi.title,
+              description: generatedUi.description,
+            };
+
+            assistantResponse = `I've created a custom "${generatedUi.title}" for you. ${generatedUi.description}`;
+          } catch (error) {
+            this.logger.warn('Generative UI creation failed, falling through to AI:', error.message);
+            // Fall through to normal AI response
+          }
+        }
+
         if (!assistantResponse) {
         // Fallback to AI using selected model with STREAMING
         try {

--- a/backend/src/modules/chat/chat.module.ts
+++ b/backend/src/modules/chat/chat.module.ts
@@ -14,6 +14,7 @@ import { AppBuilderModule } from '../app-builder/app-builder.module';
 import { AppFilesModule } from '../app-files/app-files.module';
 import { LearningModule } from '../learning/learning.module';
 import { DataAnalysisModule } from '../data-analysis/data-analysis.module';
+import { GenerativeUiModule } from '../generative-ui/generative-ui.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { DataAnalysisModule } from '../data-analysis/data-analysis.module';
     AppFilesModule,
     forwardRef(() => LearningModule),
     forwardRef(() => DataAnalysisModule),
+    GenerativeUiModule,
   ],
   controllers: [ChatController],
   providers: [ChatService, ChatGateway],

--- a/backend/src/modules/generative-ui/generative-ui.controller.ts
+++ b/backend/src/modules/generative-ui/generative-ui.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  BadRequestException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GenerativeUiService } from './generative-ui.service';
+
+class GenerateUiDto {
+  prompt: string;
+  conversationId?: string;
+}
+
+@Controller('api/v1/generative-ui')
+export class GenerativeUiController {
+  constructor(private readonly generativeUiService: GenerativeUiService) {}
+
+  @Post('generate')
+  @UseGuards(JwtAuthGuard)
+  async generate(@Body() dto: GenerateUiDto, @Req() req: any) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+
+    if (!dto.prompt || dto.prompt.trim().length === 0) {
+      throw new BadRequestException('prompt is required');
+    }
+
+    const result = await this.generativeUiService.generateUi(userId, dto.prompt, {
+      conversationId: dto.conversationId,
+    });
+
+    return result;
+  }
+
+  @Get('history/:conversationId')
+  @UseGuards(JwtAuthGuard)
+  async getHistory(
+    @Param('conversationId') conversationId: string,
+    @Req() req: any,
+  ) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.generativeUiService.getHistory(conversationId, userId);
+  }
+}

--- a/backend/src/modules/generative-ui/generative-ui.controller.ts
+++ b/backend/src/modules/generative-ui/generative-ui.controller.ts
@@ -8,11 +8,17 @@ import {
   Req,
   BadRequestException,
 } from '@nestjs/common';
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GenerativeUiService } from './generative-ui.service';
 
 class GenerateUiDto {
+  @IsString()
+  @IsNotEmpty()
   prompt: string;
+
+  @IsOptional()
+  @IsString()
   conversationId?: string;
 }
 

--- a/backend/src/modules/generative-ui/generative-ui.module.ts
+++ b/backend/src/modules/generative-ui/generative-ui.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { GenerativeUiController } from './generative-ui.controller';
+import { GenerativeUiService } from './generative-ui.service';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [GenerativeUiController],
+  providers: [GenerativeUiService],
+  exports: [GenerativeUiService],
+})
+export class GenerativeUiModule {}

--- a/backend/src/modules/generative-ui/generative-ui.module.ts
+++ b/backend/src/modules/generative-ui/generative-ui.module.ts
@@ -1,10 +1,12 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef, OnModuleInit } from '@nestjs/common';
 import { GenerativeUiController } from './generative-ui.controller';
 import { GenerativeUiService } from './generative-ui.service';
 import { AuthModule } from '../auth/auth.module';
+import { DatabaseModule } from '../database/database.module';
+import { AiModule } from '../ai/ai.module';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, DatabaseModule, forwardRef(() => AiModule)],
   controllers: [GenerativeUiController],
   providers: [GenerativeUiService],
   exports: [GenerativeUiService],

--- a/backend/src/modules/generative-ui/generative-ui.service.ts
+++ b/backend/src/modules/generative-ui/generative-ui.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AiService } from '../ai/ai.service';
+import { DatabaseService } from '../database/database.service';
+
+export interface GeneratedUi {
+  id: string;
+  user_id: string;
+  conversation_id?: string;
+  prompt: string;
+  html: string;
+  title: string;
+  description: string;
+  created_at: Date;
+}
+
+export interface GenerateUiResult {
+  html: string;
+  title: string;
+  description: string;
+}
+
+const GENERATIVE_UI_SYSTEM_PROMPT = `You are an expert frontend developer. The user will describe a tool or UI they need. You must generate a complete, self-contained HTML page that implements it.
+
+RULES:
+1. Return a complete <!DOCTYPE html> document with inline CSS and JS.
+2. Use modern CSS (flexbox/grid, CSS variables, clean typography).
+3. Make it responsive and visually polished with a clean, professional look.
+4. All JavaScript must be self-contained - no external imports or CDN links.
+5. Do NOT use any references to parent, top, window.opener, or window.parent. The page will be rendered in a sandboxed iframe.
+6. Do NOT include any tracking scripts, analytics, or external requests.
+7. Include form validation and user feedback where appropriate.
+8. Use a consistent color scheme (default to a modern blue/slate palette).
+
+Respond ONLY with the raw HTML. No markdown code fences, no explanation - just the HTML document starting with <!DOCTYPE html>.`;
+
+const TITLE_EXTRACTION_PROMPT = `Given this HTML page, extract a short title (3-8 words) and a one-sentence description. Respond ONLY with valid JSON:
+{"title": "...", "description": "..."}`;
+
+/** Score threshold below which generative UI is triggered instead of tool matching. */
+const GENERATIVE_UI_THRESHOLD = 0.3;
+
+@Injectable()
+export class GenerativeUiService {
+  private readonly logger = new Logger(GenerativeUiService.name);
+
+  constructor(
+    private readonly aiService: AiService,
+    private readonly db: DatabaseService,
+  ) {}
+
+  /**
+   * Decide whether to generate a custom UI based on the best tool-match score.
+   */
+  shouldGenerateUi(userMessage: string, matchedToolScore: number): boolean {
+    if (matchedToolScore >= GENERATIVE_UI_THRESHOLD) {
+      return false;
+    }
+    // Avoid generating UI for very short/generic messages
+    const trimmed = userMessage.trim();
+    if (trimmed.length < 10) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Generate a self-contained HTML UI for the user's request.
+   */
+  async generateUi(
+    userId: string,
+    prompt: string,
+    context?: { conversationId?: string },
+  ): Promise<GenerateUiResult> {
+    this.logger.log(`Generating UI for user ${userId}: "${prompt.substring(0, 60)}..."`);
+
+    // Generate the HTML page
+    const rawHtml = await this.aiService.generateText(prompt, {
+      systemMessage: GENERATIVE_UI_SYSTEM_PROMPT,
+      temperature: 0.7,
+      maxTokens: 8192,
+    });
+
+    // Sanitize the output
+    const html = this.sanitizeHtml(rawHtml);
+
+    // Extract title and description
+    const { title, description } = await this.extractMetadata(html, prompt);
+
+    // Persist to database
+    try {
+      await this.db.insert<GeneratedUi>('generated_uis', {
+        user_id: userId,
+        conversation_id: context?.conversationId || null,
+        prompt,
+        html,
+        title,
+        description,
+        created_at: new Date(),
+      });
+    } catch (error) {
+      // Table may not exist yet; log but don't fail
+      this.logger.warn('Failed to persist generated UI (table may not exist):', error.message);
+    }
+
+    return { html, title, description };
+  }
+
+  /**
+   * Retrieve generated UIs for a conversation.
+   */
+  async getHistory(
+    conversationId: string,
+    userId: string,
+  ): Promise<GeneratedUi[]> {
+    try {
+      return await this.db.findMany<GeneratedUi>(
+        'generated_uis',
+        { conversation_id: conversationId, user_id: userId },
+        { orderBy: 'created_at', order: 'DESC' },
+      );
+    } catch (error) {
+      this.logger.warn('Failed to query generated UI history:', error.message);
+      return [];
+    }
+  }
+
+  /**
+   * Sanitize generated HTML to prevent sandbox escapes.
+   * Strips references to parent frame, opener, and top-level window.
+   */
+  private sanitizeHtml(html: string): string {
+    let sanitized = html;
+
+    // Strip any script content that references the parent page
+    sanitized = sanitized.replace(/\bparent\./g, '/* sandbox-blocked */');
+    sanitized = sanitized.replace(/\btop\./g, '/* sandbox-blocked */');
+    sanitized = sanitized.replace(/\bwindow\.opener\b/g, '/* sandbox-blocked */');
+    sanitized = sanitized.replace(/\bwindow\.parent\b/g, '/* sandbox-blocked */');
+    sanitized = sanitized.replace(/\bwindow\.top\b/g, '/* sandbox-blocked */');
+
+    // Remove postMessage calls to parent
+    sanitized = sanitized.replace(/\.postMessage\s*\(/g, '/* sandbox-blocked */(');
+
+    // Add sandbox marker
+    if (!sanitized.includes('<!-- sandbox:')) {
+      sanitized = sanitized.replace(
+        '<!DOCTYPE html>',
+        '<!DOCTYPE html>\n<!-- sandbox: no-scripts-accessing-parent -->',
+      );
+    }
+
+    // If the AI wrapped it in markdown fences, strip those
+    sanitized = sanitized.replace(/^```html?\s*/i, '').replace(/\s*```$/i, '');
+
+    return sanitized.trim();
+  }
+
+  /**
+   * Extract a human-readable title and description from the generated HTML.
+   */
+  private async extractMetadata(
+    html: string,
+    originalPrompt: string,
+  ): Promise<{ title: string; description: string }> {
+    try {
+      // Try to extract title from <title> tag first
+      const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+      if (titleMatch && titleMatch[1] && titleMatch[1].length < 60) {
+        return {
+          title: titleMatch[1].trim(),
+          description: `Custom UI generated from: ${originalPrompt.substring(0, 120)}`,
+        };
+      }
+
+      // Fall back to AI extraction
+      const snippet = html.substring(0, 2000);
+      const response = await this.aiService.generateText(
+        `HTML snippet:\n${snippet}`,
+        {
+          systemMessage: TITLE_EXTRACTION_PROMPT,
+          responseFormat: 'json_object',
+          maxTokens: 100,
+          temperature: 0.3,
+        },
+      );
+
+      const parsed = JSON.parse(response);
+      return {
+        title: parsed.title || 'Generated UI',
+        description: parsed.description || `Custom UI for: ${originalPrompt.substring(0, 100)}`,
+      };
+    } catch {
+      return {
+        title: 'Generated UI',
+        description: `Custom UI generated from: ${originalPrompt.substring(0, 120)}`,
+      };
+    }
+  }
+}

--- a/backend/src/modules/generative-ui/generative-ui.service.ts
+++ b/backend/src/modules/generative-ui/generative-ui.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { AiService } from '../ai/ai.service';
 import { DatabaseService } from '../database/database.service';
 
@@ -40,13 +40,35 @@ const TITLE_EXTRACTION_PROMPT = `Given this HTML page, extract a short title (3-
 const GENERATIVE_UI_THRESHOLD = 0.3;
 
 @Injectable()
-export class GenerativeUiService {
+export class GenerativeUiService implements OnModuleInit {
   private readonly logger = new Logger(GenerativeUiService.name);
 
   constructor(
     private readonly aiService: AiService,
     private readonly db: DatabaseService,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS generated_uis (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id VARCHAR(255) NOT NULL,
+          conversation_id UUID,
+          prompt TEXT NOT NULL,
+          html TEXT NOT NULL,
+          title VARCHAR(255) NOT NULL DEFAULT 'Generated UI',
+          description TEXT DEFAULT '',
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+      `);
+      await this.db.query(`CREATE INDEX IF NOT EXISTS idx_generated_uis_user_id ON generated_uis(user_id)`);
+      await this.db.query(`CREATE INDEX IF NOT EXISTS idx_generated_uis_conversation ON generated_uis(conversation_id)`);
+      this.logger.log('Generated UIs table ensured');
+    } catch (error) {
+      this.logger.warn(`Failed to ensure generated_uis table: ${error.message}`);
+    }
+  }
 
   /**
    * Decide whether to generate a custom UI based on the best tool-match score.
@@ -111,13 +133,23 @@ export class GenerativeUiService {
   async getHistory(
     conversationId: string,
     userId: string,
-  ): Promise<GeneratedUi[]> {
+  ) {
     try {
-      return await this.db.findMany<GeneratedUi>(
+      const rows = await this.db.findMany<any>(
         'generated_uis',
         { conversation_id: conversationId, user_id: userId },
         { orderBy: 'created_at', order: 'DESC' },
       );
+      return rows.map((r: any) => ({
+        id: r.id,
+        userId: r.user_id,
+        conversationId: r.conversation_id,
+        prompt: r.prompt,
+        html: r.html,
+        title: r.title,
+        description: r.description,
+        createdAt: r.created_at,
+      }));
     } catch (error) {
       this.logger.warn('Failed to query generated UI history:', error.message);
       return [];

--- a/backend/src/modules/generative-ui/index.ts
+++ b/backend/src/modules/generative-ui/index.ts
@@ -1,0 +1,3 @@
+export { GenerativeUiModule } from './generative-ui.module';
+export { GenerativeUiService, GenerateUiResult, GeneratedUi } from './generative-ui.service';
+export { GenerativeUiController } from './generative-ui.controller';


### PR DESCRIPTION
## Summary
- Adds `GenerativeUiModule` in `backend/src/modules/generative-ui/` with service, controller, and module
- When intent detection scores below 0.3 (no matching pre-built tool), the AI generates a self-contained HTML page rendered in a sandboxed iframe
- `POST /api/v1/generative-ui/generate` and `GET /api/v1/generative-ui/history/:conversationId` endpoints (authed)
- HTML sanitization strips `parent.`, `top.`, `window.opener` references and adds sandbox marker
- Integrates into the chat gateway fallback path before AI streaming

Closes #47

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with 0 errors
- [ ] Send a message with no matching tool and confirm `generative-ui:created` socket event is emitted
- [ ] Verify generated HTML is sanitized (no parent/top frame access)
- [ ] Test `POST /api/v1/generative-ui/generate` with auth token
- [ ] Test `GET /api/v1/generative-ui/history/:conversationId` returns entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)