### PR TITLE
Add real-time collaborative sessions

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -43,6 +43,7 @@ import { AppBuilderModule } from './modules/app-builder/app-builder.module';
 import { ToolsApiModule } from './modules/tools-api/tools-api.module';
 import { ToolsModule } from './modules/tools/tools.module';
 import { AgentsModule } from './modules/agents/agents.module';
+import { PluginsModule } from './modules/plugins/plugins.module';
 
 @Module({
   imports: [
@@ -95,6 +96,7 @@ import { AgentsModule } from './modules/agents/agents.module';
     ToolsApiModule,
     ToolsModule,
     AgentsModule,
+    PluginsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -44,6 +44,7 @@ import { ToolsApiModule } from './modules/tools-api/tools-api.module';
 import { ToolsModule } from './modules/tools/tools.module';
 import { AgentsModule } from './modules/agents/agents.module';
 import { PluginsModule } from './modules/plugins/plugins.module';
+import { CollaborationModule } from './modules/collaboration/collaboration.module';
 
 @Module({
   imports: [
@@ -97,6 +98,7 @@ import { PluginsModule } from './modules/plugins/plugins.module';
     ToolsModule,
     AgentsModule,
     PluginsModule,
+    CollaborationModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -42,6 +42,7 @@ import { AppBuilderModule } from './modules/app-builder/app-builder.module';
 // import { AppMakerModule } from './modules/app-maker/app-maker.module';
 import { ToolsApiModule } from './modules/tools-api/tools-api.module';
 import { ToolsModule } from './modules/tools/tools.module';
+import { AgentsModule } from './modules/agents/agents.module';
 
 @Module({
   imports: [
@@ -93,6 +94,7 @@ import { ToolsModule } from './modules/tools/tools.module';
     // AppMakerModule excluded from open-source release
     ToolsApiModule,
     ToolsModule,
+    AgentsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/agents/agent-crew.controller.ts
+++ b/backend/src/modules/agents/agent-crew.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Req,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AgentCrewService } from './agent-crew.service';
+import { CreateCrewDto, ExecuteCrewDto } from './dto/create-crew.dto';
+
+@Controller('api/v1/crews')
+@UseGuards(JwtAuthGuard)
+export class AgentCrewController {
+  constructor(private readonly crewService: AgentCrewService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createCrew(@Req() req: any, @Body() dto: CreateCrewDto) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.crewService.createCrew(userId, dto);
+  }
+
+  @Get()
+  async listCrews(@Req() req: any) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.crewService.listCrews(userId);
+  }
+
+  @Get('templates')
+  async getTemplates() {
+    return this.crewService.getTemplates();
+  }
+
+  @Post(':id/execute')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async executeCrew(
+    @Req() req: any,
+    @Param('id') crewId: string,
+    @Body() dto: ExecuteCrewDto,
+  ) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.crewService.executeCrew(userId, crewId, dto.input);
+  }
+
+  @Get('executions/:id')
+  async getExecutionResult(@Req() req: any, @Param('id') executionId: string) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.crewService.getCrewResult(userId, executionId);
+  }
+}

--- a/backend/src/modules/agents/agent-crew.service.ts
+++ b/backend/src/modules/agents/agent-crew.service.ts
@@ -1,0 +1,525 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { AiService } from '../ai/ai.service';
+import { AppGateway } from '../../common/gateways/app.gateway';
+import {
+  AgentCrew,
+  AgentDefinition,
+  AgentOutput,
+  CrewExecution,
+  CrewProcess,
+  CrewTemplate,
+} from './interfaces/agent-crew.interfaces';
+import { CreateCrewDto } from './dto/create-crew.dto';
+
+@Injectable()
+export class AgentCrewService {
+  private readonly logger = new Logger(AgentCrewService.name);
+
+  private readonly templates: CrewTemplate[] = [
+    {
+      name: 'Research & Write',
+      description:
+        'A crew that researches a topic, writes an article, and polishes the final output.',
+      process: 'sequential',
+      agents: [
+        {
+          name: 'Researcher',
+          role: 'Research Specialist',
+          systemPrompt:
+            'You are a research specialist. Given a topic, produce a comprehensive research summary with key facts, statistics, and insights. Be thorough and cite your reasoning.',
+          tools: ['web_search'],
+        },
+        {
+          name: 'Writer',
+          role: 'Content Writer',
+          systemPrompt:
+            'You are a skilled content writer. Using the research provided, compose a well-structured, engaging article. Include an introduction, body sections, and conclusion.',
+          tools: ['content'],
+        },
+        {
+          name: 'Editor',
+          role: 'Editor & Reviewer',
+          systemPrompt:
+            'You are a meticulous editor. Review the article for clarity, grammar, factual accuracy, and flow. Provide the final polished version.',
+          tools: ['content'],
+        },
+      ],
+    },
+    {
+      name: 'Code Review',
+      description:
+        'A crew that analyzes code for issues, suggests fixes, and verifies the corrections.',
+      process: 'sequential',
+      agents: [
+        {
+          name: 'Analyzer',
+          role: 'Code Analyzer',
+          systemPrompt:
+            'You are a code analysis expert. Examine the provided code and identify bugs, security vulnerabilities, performance issues, and anti-patterns. List each issue clearly.',
+          tools: ['code'],
+        },
+        {
+          name: 'Reviewer',
+          role: 'Fix Suggester',
+          systemPrompt:
+            'You are a senior developer. Given a list of code issues, suggest concrete fixes for each one with corrected code snippets and explanations.',
+          tools: ['code'],
+        },
+        {
+          name: 'Verifier',
+          role: 'Fix Verifier',
+          systemPrompt:
+            'You are a QA engineer. Review the suggested fixes and verify they correctly address the original issues without introducing new problems. Provide a final verdict.',
+          tools: ['code'],
+        },
+      ],
+    },
+    {
+      name: 'Business Analysis',
+      description:
+        'A crew that collects business data, analyzes trends, and produces a strategic report.',
+      process: 'sequential',
+      agents: [
+        {
+          name: 'Data Collector',
+          role: 'Data Collection Specialist',
+          systemPrompt:
+            'You are a data collection specialist. Given a business topic or question, gather relevant data points, market information, and competitive intelligence. Present the raw data in an organized format.',
+          tools: ['web_search', 'data_analysis'],
+        },
+        {
+          name: 'Analyst',
+          role: 'Business Analyst',
+          systemPrompt:
+            'You are a business analyst. Using the collected data, identify trends, patterns, opportunities, and risks. Provide analytical insights with supporting evidence.',
+          tools: ['data_analysis'],
+        },
+        {
+          name: 'Report Writer',
+          role: 'Report Writer',
+          systemPrompt:
+            'You are an executive report writer. Using the analysis provided, compose a professional business report with an executive summary, key findings, recommendations, and next steps.',
+          tools: ['content'],
+        },
+      ],
+    },
+  ];
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly aiService: AiService,
+    private readonly gateway: AppGateway,
+  ) {}
+
+  async ensureTables(): Promise<void> {
+    try {
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS agent_crews (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id VARCHAR(255) NOT NULL,
+          name VARCHAR(255) NOT NULL,
+          description TEXT DEFAULT '',
+          process VARCHAR(50) NOT NULL DEFAULT 'sequential',
+          agents JSONB NOT NULL DEFAULT '[]',
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_agent_crews_user_id ON agent_crews(user_id)
+      `);
+
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS crew_executions (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          crew_id UUID NOT NULL REFERENCES agent_crews(id) ON DELETE CASCADE,
+          user_id VARCHAR(255) NOT NULL,
+          input TEXT NOT NULL,
+          status VARCHAR(50) NOT NULL DEFAULT 'pending',
+          agent_outputs JSONB NOT NULL DEFAULT '[]',
+          final_output TEXT,
+          started_at TIMESTAMPTZ DEFAULT NOW(),
+          completed_at TIMESTAMPTZ
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_crew_executions_crew_id ON crew_executions(crew_id)
+      `);
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_crew_executions_user_id ON crew_executions(user_id)
+      `);
+
+      this.logger.log('Agent crew tables ensured');
+    } catch (error) {
+      this.logger.warn(`Failed to ensure agent crew tables: ${error.message}`);
+    }
+  }
+
+  // ============================================
+  // CRUD
+  // ============================================
+
+  async createCrew(userId: string, dto: CreateCrewDto): Promise<AgentCrew> {
+    if (!dto.name || !dto.agents || dto.agents.length === 0) {
+      throw new BadRequestException('Crew must have a name and at least one agent');
+    }
+
+    if (!['sequential', 'parallel'].includes(dto.process)) {
+      throw new BadRequestException('Process must be sequential or parallel');
+    }
+
+    for (const agent of dto.agents) {
+      if (!agent.name || !agent.role || !agent.systemPrompt) {
+        throw new BadRequestException(
+          'Each agent must have a name, role, and systemPrompt',
+        );
+      }
+    }
+
+    const crew = await this.db.insert<AgentCrew>('agent_crews', {
+      user_id: userId,
+      name: dto.name,
+      description: dto.description || '',
+      process: dto.process,
+      agents: JSON.stringify(dto.agents),
+      created_at: new Date(),
+    });
+
+    return this.transformCrew(crew);
+  }
+
+  async listCrews(userId: string): Promise<AgentCrew[]> {
+    const crews = await this.db.findMany<AgentCrew>(
+      'agent_crews',
+      { user_id: userId },
+      { orderBy: 'created_at', order: 'DESC' },
+    );
+    return crews.map((c) => this.transformCrew(c));
+  }
+
+  async getCrewById(userId: string, crewId: string): Promise<AgentCrew> {
+    const crew = await this.db.findOne<AgentCrew>('agent_crews', { id: crewId });
+    if (!crew) {
+      throw new NotFoundException('Crew not found');
+    }
+    if (crew.user_id !== userId) {
+      throw new NotFoundException('Crew not found');
+    }
+    return this.transformCrew(crew);
+  }
+
+  // ============================================
+  // Templates
+  // ============================================
+
+  getTemplates(): CrewTemplate[] {
+    return this.templates;
+  }
+
+  // ============================================
+  // Execution
+  // ============================================
+
+  async executeCrew(
+    userId: string,
+    crewId: string,
+    input: string,
+  ): Promise<CrewExecution> {
+    const crew = await this.getCrewById(userId, crewId);
+
+    // Create execution record
+    const execution = await this.db.insert<CrewExecution>('crew_executions', {
+      crew_id: crewId,
+      user_id: userId,
+      input,
+      status: 'running',
+      agent_outputs: JSON.stringify([]),
+      started_at: new Date(),
+    });
+
+    const executionId = execution.id;
+
+    // Emit start event
+    this.emitToUser(userId, 'crew:execution:started', {
+      executionId,
+      crewId,
+      crewName: crew.name,
+      process: crew.process,
+      agentCount: crew.agents.length,
+    });
+
+    // Run asynchronously
+    this.runCrewExecution(userId, crew, executionId, input).catch((err) => {
+      this.logger.error(`Crew execution ${executionId} failed: ${err.message}`);
+    });
+
+    return this.transformExecution(execution);
+  }
+
+  async getCrewResult(userId: string, executionId: string): Promise<CrewExecution> {
+    const execution = await this.db.findOne<CrewExecution>('crew_executions', {
+      id: executionId,
+    });
+    if (!execution) {
+      throw new NotFoundException('Execution not found');
+    }
+    if (execution.user_id !== userId) {
+      throw new NotFoundException('Execution not found');
+    }
+    return this.transformExecution(execution);
+  }
+
+  // ============================================
+  // Private execution logic
+  // ============================================
+
+  private async runCrewExecution(
+    userId: string,
+    crew: AgentCrew,
+    executionId: string,
+    input: string,
+  ): Promise<void> {
+    const agentOutputs: AgentOutput[] = [];
+
+    try {
+      if (crew.process === 'sequential') {
+        await this.runSequential(userId, crew, executionId, input, agentOutputs);
+      } else {
+        await this.runParallel(userId, crew, executionId, input, agentOutputs);
+      }
+
+      // Determine final output
+      const finalOutput =
+        crew.process === 'sequential'
+          ? agentOutputs[agentOutputs.length - 1]?.output || ''
+          : this.mergeParallelOutputs(agentOutputs);
+
+      // Update execution as completed
+      await this.db.update(
+        'crew_executions',
+        { id: executionId },
+        {
+          status: 'completed',
+          agent_outputs: JSON.stringify(agentOutputs),
+          final_output: finalOutput,
+          completed_at: new Date(),
+        },
+      );
+
+      this.emitToUser(userId, 'crew:execution:completed', {
+        executionId,
+        finalOutput,
+        agentOutputs,
+      });
+    } catch (error) {
+      await this.db.update(
+        'crew_executions',
+        { id: executionId },
+        {
+          status: 'failed',
+          agent_outputs: JSON.stringify(agentOutputs),
+          final_output: `Execution failed: ${error.message}`,
+          completed_at: new Date(),
+        },
+      );
+
+      this.emitToUser(userId, 'crew:execution:failed', {
+        executionId,
+        error: error.message,
+      });
+    }
+  }
+
+  private async runSequential(
+    userId: string,
+    crew: AgentCrew,
+    executionId: string,
+    input: string,
+    agentOutputs: AgentOutput[],
+  ): Promise<void> {
+    let currentInput = input;
+
+    for (let i = 0; i < crew.agents.length; i++) {
+      const agent = crew.agents[i];
+      const stepStart = new Date();
+
+      this.emitToUser(userId, 'crew:agent:started', {
+        executionId,
+        agentIndex: i,
+        agentName: agent.name,
+        agentRole: agent.role,
+      });
+
+      const prompt = i === 0
+        ? currentInput
+        : `Previous agent output:\n\n${currentInput}\n\nOriginal user request: ${input}`;
+
+      const output = await this.aiService.generateText(prompt, {
+        systemMessage: agent.systemPrompt,
+        temperature: 0.7,
+        maxTokens: 4096,
+      });
+
+      const stepEnd = new Date();
+
+      const agentOutput: AgentOutput = {
+        agentName: agent.name,
+        agentRole: agent.role,
+        input: currentInput,
+        output,
+        startedAt: stepStart.toISOString(),
+        completedAt: stepEnd.toISOString(),
+      };
+
+      agentOutputs.push(agentOutput);
+      currentInput = output;
+
+      // Update execution with progress
+      await this.db.update(
+        'crew_executions',
+        { id: executionId },
+        { agent_outputs: JSON.stringify(agentOutputs) },
+      );
+
+      this.emitToUser(userId, 'crew:agent:completed', {
+        executionId,
+        agentIndex: i,
+        agentName: agent.name,
+        agentRole: agent.role,
+        output,
+      });
+    }
+  }
+
+  private async runParallel(
+    userId: string,
+    crew: AgentCrew,
+    executionId: string,
+    input: string,
+    agentOutputs: AgentOutput[],
+  ): Promise<void> {
+    // Emit start for all agents
+    crew.agents.forEach((agent, i) => {
+      this.emitToUser(userId, 'crew:agent:started', {
+        executionId,
+        agentIndex: i,
+        agentName: agent.name,
+        agentRole: agent.role,
+      });
+    });
+
+    const results = await Promise.all(
+      crew.agents.map(async (agent, i) => {
+        const stepStart = new Date();
+
+        const output = await this.aiService.generateText(input, {
+          systemMessage: agent.systemPrompt,
+          temperature: 0.7,
+          maxTokens: 4096,
+        });
+
+        const stepEnd = new Date();
+
+        const agentOutput: AgentOutput = {
+          agentName: agent.name,
+          agentRole: agent.role,
+          input,
+          output,
+          startedAt: stepStart.toISOString(),
+          completedAt: stepEnd.toISOString(),
+        };
+
+        this.emitToUser(userId, 'crew:agent:completed', {
+          executionId,
+          agentIndex: i,
+          agentName: agent.name,
+          agentRole: agent.role,
+          output,
+        });
+
+        return agentOutput;
+      }),
+    );
+
+    agentOutputs.push(...results);
+
+    await this.db.update(
+      'crew_executions',
+      { id: executionId },
+      { agent_outputs: JSON.stringify(agentOutputs) },
+    );
+  }
+
+  private mergeParallelOutputs(outputs: AgentOutput[]): string {
+    const sections = outputs.map(
+      (o) => `## ${o.agentName} (${o.agentRole})\n\n${o.output}`,
+    );
+    return sections.join('\n\n---\n\n');
+  }
+
+  // ============================================
+  // Helpers
+  // ============================================
+
+  private emitToUser(userId: string, event: string, data: any): void {
+    try {
+      this.gateway.server.to(`user:${userId}`).emit(event, {
+        ...data,
+        timestamp: new Date().toISOString(),
+      });
+    } catch {
+      // WebSocket emission is best-effort
+    }
+  }
+
+  private transformCrew(crew: any): AgentCrew {
+    let agents = crew.agents;
+    if (typeof agents === 'string') {
+      try {
+        agents = JSON.parse(agents);
+      } catch {
+        agents = [];
+      }
+    }
+
+    return {
+      id: crew.id,
+      user_id: crew.user_id,
+      name: crew.name,
+      description: crew.description || '',
+      process: crew.process,
+      agents,
+      created_at: crew.created_at,
+    };
+  }
+
+  private transformExecution(execution: any): CrewExecution {
+    let agentOutputs = execution.agent_outputs;
+    if (typeof agentOutputs === 'string') {
+      try {
+        agentOutputs = JSON.parse(agentOutputs);
+      } catch {
+        agentOutputs = [];
+      }
+    }
+
+    return {
+      id: execution.id,
+      crew_id: execution.crew_id,
+      user_id: execution.user_id,
+      input: execution.input,
+      status: execution.status,
+      agent_outputs: agentOutputs,
+      final_output: execution.final_output,
+      started_at: execution.started_at,
+      completed_at: execution.completed_at,
+    };
+  }
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -1,0 +1,20 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+import { AgentCrewService } from './agent-crew.service';
+import { AgentCrewController } from './agent-crew.controller';
+import { DatabaseModule } from '../database/database.module';
+import { AiModule } from '../ai/ai.module';
+import { WebSocketModule } from '../../common/gateways/websocket.module';
+
+@Module({
+  imports: [DatabaseModule, AiModule, WebSocketModule],
+  controllers: [AgentCrewController],
+  providers: [AgentCrewService],
+  exports: [AgentCrewService],
+})
+export class AgentsModule implements OnModuleInit {
+  constructor(private readonly crewService: AgentCrewService) {}
+
+  async onModuleInit() {
+    await this.crewService.ensureTables();
+  }
+}

--- a/backend/src/modules/agents/dto/create-crew.dto.ts
+++ b/backend/src/modules/agents/dto/create-crew.dto.ts
@@ -1,0 +1,12 @@
+import { AgentDefinition, CrewProcess } from '../interfaces/agent-crew.interfaces';
+
+export class CreateCrewDto {
+  name: string;
+  description: string;
+  process: CrewProcess;
+  agents: AgentDefinition[];
+}
+
+export class ExecuteCrewDto {
+  input: string;
+}

--- a/backend/src/modules/agents/interfaces/agent-crew.interfaces.ts
+++ b/backend/src/modules/agents/interfaces/agent-crew.interfaces.ts
@@ -1,0 +1,48 @@
+export type CrewProcess = 'sequential' | 'parallel';
+
+export type CrewExecutionStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface AgentDefinition {
+  name: string;
+  role: string;
+  systemPrompt: string;
+  tools: string[];
+}
+
+export interface AgentCrew {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string;
+  process: CrewProcess;
+  agents: AgentDefinition[];
+  created_at: Date;
+}
+
+export interface AgentOutput {
+  agentName: string;
+  agentRole: string;
+  input: string;
+  output: string;
+  startedAt: string;
+  completedAt: string;
+}
+
+export interface CrewExecution {
+  id: string;
+  crew_id: string;
+  user_id: string;
+  input: string;
+  status: CrewExecutionStatus;
+  agent_outputs: AgentOutput[];
+  final_output: string | null;
+  started_at: Date;
+  completed_at: Date | null;
+}
+
+export interface CrewTemplate {
+  name: string;
+  description: string;
+  process: CrewProcess;
+  agents: AgentDefinition[];
+}

--- a/backend/src/modules/collaboration/collaboration.controller.ts
+++ b/backend/src/modules/collaboration/collaboration.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CollaborationService, CreateSessionDto, JoinSessionDto } from './collaboration.service';
+
+@Controller('api/v1/collab')
+export class CollaborationController {
+  constructor(private readonly collaborationService: CollaborationService) {}
+
+  @Post('sessions')
+  @UseGuards(JwtAuthGuard)
+  async createSession(@Req() req: any, @Body() dto: CreateSessionDto) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.collaborationService.createSession(userId, dto);
+  }
+
+  @Post('sessions/join')
+  @UseGuards(JwtAuthGuard)
+  async joinSession(@Req() req: any, @Body() dto: JoinSessionDto) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.collaborationService.joinSession(userId, dto);
+  }
+
+  @Get('sessions/:id')
+  @UseGuards(JwtAuthGuard)
+  async getSession(@Req() req: any, @Param('id') id: string) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.collaborationService.getSession(id, userId);
+  }
+
+  @Delete('sessions/:id/leave')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async leaveSession(@Req() req: any, @Param('id') id: string) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    await this.collaborationService.leaveSession(userId, id);
+  }
+}

--- a/backend/src/modules/collaboration/collaboration.gateway.ts
+++ b/backend/src/modules/collaboration/collaboration.gateway.ts
@@ -1,0 +1,134 @@
+import {
+  WebSocketGateway,
+  SubscribeMessage,
+  ConnectedSocket,
+  MessageBody,
+} from '@nestjs/websockets';
+import { Logger } from '@nestjs/common';
+import { AuthenticatedSocket } from '../../common/gateways/app.gateway';
+import { CollaborationService } from './collaboration.service';
+
+@WebSocketGateway({
+  cors: {
+    origin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
+    credentials: true,
+  },
+  namespace: '/',
+  transports: ['websocket', 'polling'],
+})
+export class CollaborationGateway {
+  private readonly logger = new Logger(CollaborationGateway.name);
+
+  constructor(private readonly collaborationService: CollaborationService) {}
+
+  @SubscribeMessage('collab:join')
+  async handleCollabJoin(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { sessionId: string },
+  ) {
+    if (!client.userId) return;
+
+    try {
+      const room = `collab:${data.sessionId}`;
+      await client.join(room);
+
+      // Notify the room
+      client.to(room).emit('collab:participants', {
+        action: 'connected',
+        userId: client.userId,
+        sessionId: data.sessionId,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Send current state to the joining user
+      const state = await this.collaborationService.getSessionState(data.sessionId);
+      client.emit('collab:state-update', {
+        sessionId: data.sessionId,
+        userId: 'system',
+        stateUpdate: state,
+        type: 'full_state',
+        timestamp: new Date().toISOString(),
+      });
+
+      // Send participant list
+      const participants = await this.collaborationService.getSessionParticipants(data.sessionId);
+      client.emit('collab:participants', {
+        action: 'list',
+        participants,
+        sessionId: data.sessionId,
+        timestamp: new Date().toISOString(),
+      });
+
+      this.logger.debug(`User ${client.userId} joined collab room: ${room}`);
+    } catch (error) {
+      client.emit('error', {
+        message: 'Failed to join collaboration session',
+        code: 'COLLAB_JOIN_ERROR',
+      });
+      this.logger.error(`collab:join error: ${error.message}`);
+    }
+  }
+
+  @SubscribeMessage('collab:leave')
+  async handleCollabLeave(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { sessionId: string },
+  ) {
+    if (!client.userId) return;
+
+    try {
+      const room = `collab:${data.sessionId}`;
+      await client.leave(room);
+
+      client.to(room).emit('collab:participants', {
+        action: 'disconnected',
+        userId: client.userId,
+        sessionId: data.sessionId,
+        timestamp: new Date().toISOString(),
+      });
+
+      this.logger.debug(`User ${client.userId} left collab room: ${room}`);
+    } catch (error) {
+      this.logger.error(`collab:leave error: ${error.message}`);
+    }
+  }
+
+  @SubscribeMessage('collab:state-update')
+  async handleStateUpdate(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { sessionId: string; stateUpdate: Record<string, any> },
+  ) {
+    if (!client.userId) return;
+
+    try {
+      await this.collaborationService.broadcastState(
+        data.sessionId,
+        client.userId,
+        data.stateUpdate,
+      );
+    } catch (error) {
+      client.emit('error', {
+        message: 'Failed to update state',
+        code: 'COLLAB_STATE_ERROR',
+      });
+      this.logger.error(`collab:state-update error: ${error.message}`);
+    }
+  }
+
+  @SubscribeMessage('collab:cursor-move')
+  async handleCursorMove(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { sessionId: string; cursor: { x: number; y: number; element?: string } },
+  ) {
+    if (!client.userId) return;
+
+    // Broadcast cursor position to all other participants (no persistence needed)
+    const room = `collab:${data.sessionId}`;
+    client.to(room).emit('collab:cursor-move', {
+      userId: client.userId,
+      cursor: data.cursor,
+      sessionId: data.sessionId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/backend/src/modules/collaboration/collaboration.gateway.ts
+++ b/backend/src/modules/collaboration/collaboration.gateway.ts
@@ -13,7 +13,7 @@ import { CollaborationService } from './collaboration.service';
     origin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
     credentials: true,
   },
-  namespace: '/',
+  namespace: '/collab',
   transports: ['websocket', 'polling'],
 })
 export class CollaborationGateway {

--- a/backend/src/modules/collaboration/collaboration.module.ts
+++ b/backend/src/modules/collaboration/collaboration.module.ts
@@ -4,9 +4,10 @@ import { CollaborationController } from './collaboration.controller';
 import { CollaborationGateway } from './collaboration.gateway';
 import { WebSocketModule } from '../../common/gateways/websocket.module';
 import { AuthModule } from '../auth/auth.module';
+import { DatabaseModule } from '../database/database.module';
 
 @Module({
-  imports: [WebSocketModule, AuthModule],
+  imports: [WebSocketModule, AuthModule, DatabaseModule],
   controllers: [CollaborationController],
   providers: [CollaborationService, CollaborationGateway],
   exports: [CollaborationService],

--- a/backend/src/modules/collaboration/collaboration.module.ts
+++ b/backend/src/modules/collaboration/collaboration.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { CollaborationService } from './collaboration.service';
+import { CollaborationController } from './collaboration.controller';
+import { CollaborationGateway } from './collaboration.gateway';
+import { WebSocketModule } from '../../common/gateways/websocket.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [WebSocketModule, AuthModule],
+  controllers: [CollaborationController],
+  providers: [CollaborationService, CollaborationGateway],
+  exports: [CollaborationService],
+})
+export class CollaborationModule {}

--- a/backend/src/modules/collaboration/collaboration.service.ts
+++ b/backend/src/modules/collaboration/collaboration.service.ts
@@ -1,0 +1,331 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { AppGateway } from '../../common/gateways/app.gateway';
+import * as crypto from 'crypto';
+
+// ── Interfaces ──────────────────────────────────────────────
+
+export interface CollabSession {
+  id: string;
+  creatorId: string;
+  toolId: string;
+  sessionCode: string;
+  conversationId: string | null;
+  state: Record<string, any>;
+  isActive: boolean;
+  createdAt: Date;
+}
+
+export interface CollabParticipant {
+  id: string;
+  sessionId: string;
+  userId: string;
+  joinedAt: Date;
+  leftAt: Date | null;
+}
+
+export interface CreateSessionDto {
+  toolId: string;
+  conversationId?: string;
+}
+
+export interface JoinSessionDto {
+  sessionCode: string;
+}
+
+export interface StateUpdateDto {
+  sessionId: string;
+  stateUpdate: Record<string, any>;
+}
+
+// ── Service ─────────────────────────────────────────────────
+
+@Injectable()
+export class CollaborationService {
+  private readonly logger = new Logger(CollaborationService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly gateway: AppGateway,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS collab_sessions (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          creator_id VARCHAR(255) NOT NULL,
+          tool_id VARCHAR(255) NOT NULL,
+          session_code VARCHAR(6) NOT NULL UNIQUE,
+          conversation_id UUID,
+          state JSONB DEFAULT '{}',
+          is_active BOOLEAN DEFAULT true,
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_collab_sessions_code
+        ON collab_sessions(session_code)
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_collab_sessions_creator
+        ON collab_sessions(creator_id)
+      `);
+
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS collab_participants (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          session_id UUID NOT NULL REFERENCES collab_sessions(id) ON DELETE CASCADE,
+          user_id VARCHAR(255) NOT NULL,
+          joined_at TIMESTAMPTZ DEFAULT NOW(),
+          left_at TIMESTAMPTZ
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_collab_participants_session
+        ON collab_participants(session_id)
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_collab_participants_user
+        ON collab_participants(user_id)
+      `);
+
+      this.logger.log('Collaboration tables ready');
+    } catch (error) {
+      this.logger.warn(`Failed to ensure collaboration tables: ${error.message}`);
+    }
+  }
+
+  // ── Session Management ──────────────────────────────────
+
+  async createSession(userId: string, dto: CreateSessionDto): Promise<CollabSession> {
+    const sessionCode = this.generateSessionCode();
+
+    const session = await this.db.insert<any>('collab_sessions', {
+      creator_id: userId,
+      tool_id: dto.toolId,
+      session_code: sessionCode,
+      conversation_id: dto.conversationId || null,
+      state: JSON.stringify({}),
+      is_active: true,
+      created_at: new Date(),
+    });
+
+    // Automatically add creator as a participant
+    await this.db.insert('collab_participants', {
+      session_id: session.id,
+      user_id: userId,
+      joined_at: new Date(),
+    });
+
+    this.logger.log(`Collaboration session created: ${session.id} (code: ${sessionCode})`);
+    return this.mapSession(session);
+  }
+
+  async joinSession(userId: string, dto: JoinSessionDto): Promise<CollabSession> {
+    const session = await this.db.findOne<any>('collab_sessions', {
+      session_code: dto.sessionCode.toUpperCase(),
+    });
+
+    if (!session) {
+      throw new NotFoundException('Session not found. Check the code and try again.');
+    }
+
+    if (!session.is_active) {
+      throw new BadRequestException('This session is no longer active');
+    }
+
+    // Check if user is already a participant
+    const existing = await this.db.findOne<any>('collab_participants', {
+      session_id: session.id,
+      user_id: userId,
+    });
+
+    if (existing && !existing.left_at) {
+      // Already in the session, just return it
+      return this.mapSession(session);
+    }
+
+    if (existing && existing.left_at) {
+      // Rejoin: clear left_at
+      await this.db.update('collab_participants', { id: existing.id }, {
+        left_at: null,
+        joined_at: new Date(),
+      });
+    } else {
+      // New participant
+      await this.db.insert('collab_participants', {
+        session_id: session.id,
+        user_id: userId,
+        joined_at: new Date(),
+      });
+    }
+
+    // Notify other participants via WebSocket
+    this.gateway.emitToRoom(`collab:${session.id}`, 'collab:participants', {
+      action: 'joined',
+      userId,
+      sessionId: session.id,
+    });
+
+    this.logger.log(`User ${userId} joined session ${session.id}`);
+    return this.mapSession(session);
+  }
+
+  async leaveSession(userId: string, sessionId: string): Promise<void> {
+    const session = await this.db.findOne<any>('collab_sessions', { id: sessionId });
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    const participant = await this.db.findOne<any>('collab_participants', {
+      session_id: sessionId,
+      user_id: userId,
+    });
+
+    if (!participant || participant.left_at) {
+      throw new BadRequestException('You are not in this session');
+    }
+
+    await this.db.update('collab_participants', { id: participant.id }, {
+      left_at: new Date(),
+    });
+
+    // Notify other participants
+    this.gateway.emitToRoom(`collab:${sessionId}`, 'collab:participants', {
+      action: 'left',
+      userId,
+      sessionId,
+    });
+
+    // If creator leaves, deactivate the session
+    if (session.creator_id === userId) {
+      await this.db.update('collab_sessions', { id: sessionId }, { is_active: false });
+      this.gateway.emitToRoom(`collab:${sessionId}`, 'collab:state-update', {
+        type: 'session_ended',
+        sessionId,
+      });
+    }
+
+    this.logger.log(`User ${userId} left session ${sessionId}`);
+  }
+
+  async getSessionParticipants(sessionId: string): Promise<CollabParticipant[]> {
+    const rows = await this.db.findMany<any>('collab_participants', {
+      session_id: sessionId,
+    }, { orderBy: 'joined_at', order: 'ASC' });
+
+    // Filter to only active participants (no left_at)
+    return rows
+      .filter((r: any) => !r.left_at)
+      .map((r: any) => this.mapParticipant(r));
+  }
+
+  async getSession(sessionId: string, userId: string): Promise<{
+    session: CollabSession;
+    participants: CollabParticipant[];
+  }> {
+    const session = await this.db.findOne<any>('collab_sessions', { id: sessionId });
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    // Verify user is a participant
+    const participant = await this.db.findOne<any>('collab_participants', {
+      session_id: sessionId,
+      user_id: userId,
+    });
+
+    if (!participant || participant.left_at) {
+      throw new ForbiddenException('You are not a participant in this session');
+    }
+
+    const participants = await this.getSessionParticipants(sessionId);
+
+    return {
+      session: this.mapSession(session),
+      participants,
+    };
+  }
+
+  // ── State Management ────────────────────────────────────
+
+  async broadcastState(
+    sessionId: string,
+    userId: string,
+    stateUpdate: Record<string, any>,
+  ): Promise<void> {
+    const session = await this.db.findOne<any>('collab_sessions', { id: sessionId });
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    if (!session.is_active) {
+      throw new BadRequestException('Session is no longer active');
+    }
+
+    // Merge state update into session state
+    const currentState = typeof session.state === 'string' ? JSON.parse(session.state) : (session.state || {});
+    const mergedState = { ...currentState, ...stateUpdate };
+
+    await this.db.update('collab_sessions', { id: sessionId }, {
+      state: JSON.stringify(mergedState),
+    });
+
+    // Broadcast to all participants in the room
+    this.gateway.emitToRoom(`collab:${sessionId}`, 'collab:state-update', {
+      sessionId,
+      userId,
+      stateUpdate,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  async getSessionState(sessionId: string): Promise<Record<string, any>> {
+    const session = await this.db.findOne<any>('collab_sessions', { id: sessionId });
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+
+    return typeof session.state === 'string' ? JSON.parse(session.state) : (session.state || {});
+  }
+
+  // ── Private Helpers ─────────────────────────────────────
+
+  private generateSessionCode(): string {
+    return crypto.randomBytes(3).toString('hex').toUpperCase().substring(0, 6);
+  }
+
+  private mapSession(row: any): CollabSession {
+    return {
+      id: row.id,
+      creatorId: row.creator_id,
+      toolId: row.tool_id,
+      sessionCode: row.session_code,
+      conversationId: row.conversation_id || null,
+      state: typeof row.state === 'string' ? JSON.parse(row.state) : (row.state || {}),
+      isActive: row.is_active,
+      createdAt: new Date(row.created_at),
+    };
+  }
+
+  private mapParticipant(row: any): CollabParticipant {
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      userId: row.user_id,
+      joinedAt: new Date(row.joined_at),
+      leftAt: row.left_at ? new Date(row.left_at) : null,
+    };
+  }
+}

--- a/backend/src/modules/collaboration/collaboration.service.ts
+++ b/backend/src/modules/collaboration/collaboration.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   BadRequestException,
   ForbiddenException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
 import { AppGateway } from '../../common/gateways/app.gateway';
@@ -47,7 +48,7 @@ export interface StateUpdateDto {
 // ── Service ─────────────────────────────────────────────────
 
 @Injectable()
-export class CollaborationService {
+export class CollaborationService implements OnModuleInit {
   private readonly logger = new Logger(CollaborationService.name);
 
   constructor(

--- a/backend/src/modules/collaboration/index.ts
+++ b/backend/src/modules/collaboration/index.ts
@@ -1,0 +1,4 @@
+export * from './collaboration.module';
+export * from './collaboration.service';
+export * from './collaboration.controller';
+export * from './collaboration.gateway';

--- a/backend/src/modules/context/context-builder.service.ts
+++ b/backend/src/modules/context/context-builder.service.ts
@@ -5,6 +5,7 @@ import { DatabaseService } from '../database/database.service';
 import { ToolSearchService } from '../tool-search/tool-search.service';
 import { ToolIntentExtractionService } from './tool-intent-extraction.service';
 import { ToolIntentResultDto, AttachmentInputDto, FileCategory, getFileCategoryFromMime } from './dto/tool-intent.dto';
+import { PluginRegistryService } from '../plugins/plugin-registry.service';
 import * as XLSX from 'xlsx';
 
 interface ChatMessage {
@@ -129,6 +130,7 @@ export class ContextBuilderService {
     private readonly contextService: ContextService,
     private readonly toolSearchService: ToolSearchService,
     private readonly toolIntentExtractionService: ToolIntentExtractionService,
+    private readonly pluginRegistryService: PluginRegistryService,
   ) {}
 
   /**
@@ -187,6 +189,13 @@ export class ContextBuilderService {
     if (toolsResult.content) {
       messages[0].content += toolsResult.content; // Append to system prompt
       totalTokens += toolsResult.estimatedTokens;
+    }
+
+    // 2.6. Add enabled plugin tools to context
+    const pluginToolsResult = await this.addPluginToolsToContext(userId);
+    if (pluginToolsResult.content) {
+      messages[0].content += pluginToolsResult.content;
+      totalTokens += pluginToolsResult.estimatedTokens;
     }
 
     // 3. Fetch conversation summaries (for older context)
@@ -753,6 +762,45 @@ Note: Only suggest tools when they directly help with the user's request. Don't 
     } catch (error) {
       this.logger.error('Failed to add tools to context:', error.message);
       return { content: '', estimatedTokens: 0, tools: [] };
+    }
+  }
+
+  /**
+   * Add plugin tools to context for users who have enabled plugins.
+   * Plugin tools appear alongside built-in tools in the AI context.
+   */
+  private async addPluginToolsToContext(
+    userId: string,
+  ): Promise<{ content: string; estimatedTokens: number }> {
+    try {
+      const pluginTools = await this.pluginRegistryService.getUserPluginTools(userId);
+
+      if (pluginTools.length === 0) {
+        return { content: '', estimatedTokens: 0 };
+      }
+
+      const toolsList = pluginTools
+        .map((t) => `- **${t.toolName}** (plugin: ${t.pluginName}): ${t.description}`)
+        .join('\n');
+
+      const pluginContent = `\n\n## Plugin Tools
+The user has enabled the following plugin tools. These work like built-in tools but are provided by community plugins:
+
+${toolsList}
+
+When a plugin tool matches the user's request, mention it by name in bold.`;
+
+      this.logger.debug(
+        `Added ${pluginTools.length} plugin tools to context for user ${userId}`,
+      );
+
+      return {
+        content: pluginContent,
+        estimatedTokens: this.estimateTokens(pluginContent),
+      };
+    } catch (error) {
+      this.logger.error('Failed to add plugin tools to context:', error.message);
+      return { content: '', estimatedTokens: 0 };
     }
   }
 

--- a/backend/src/modules/context/context.module.ts
+++ b/backend/src/modules/context/context.module.ts
@@ -13,9 +13,10 @@ import { AiModule } from '../ai/ai.module';
 import { AuthModule } from '../auth/auth.module';
 import { MemoryModule } from '../memory/memory.module';
 import { ToolSearchModule } from '../tool-search/tool-search.module';
+import { PluginsModule } from '../plugins/plugins.module';
 
 @Module({
-  imports: [DatabaseModule, forwardRef(() => AiModule), AuthModule, MemoryModule, ToolSearchModule],
+  imports: [DatabaseModule, forwardRef(() => AiModule), AuthModule, MemoryModule, ToolSearchModule, PluginsModule],
   controllers: [ContextController, BranchingController],
   providers: [
     ContextService,

--- a/backend/src/modules/plugins/dto/index.ts
+++ b/backend/src/modules/plugins/dto/index.ts
@@ -1,0 +1,1 @@
+export { RegisterPluginDto, PluginFilterDto } from './register-plugin.dto';

--- a/backend/src/modules/plugins/dto/register-plugin.dto.ts
+++ b/backend/src/modules/plugins/dto/register-plugin.dto.ts
@@ -1,0 +1,13 @@
+import { PluginManifest } from '../interfaces';
+
+export class RegisterPluginDto {
+  manifest: PluginManifest;
+}
+
+export class PluginFilterDto {
+  search?: string;
+  author?: string;
+  is_active?: boolean;
+  limit?: number;
+  offset?: number;
+}

--- a/backend/src/modules/plugins/index.ts
+++ b/backend/src/modules/plugins/index.ts
@@ -1,0 +1,2 @@
+export { PluginsModule } from './plugins.module';
+export { PluginRegistryService } from './plugin-registry.service';

--- a/backend/src/modules/plugins/interfaces/index.ts
+++ b/backend/src/modules/plugins/interfaces/index.ts
@@ -1,0 +1,6 @@
+export {
+  PluginManifest,
+  PluginToolDefinition,
+  Plugin,
+  UserPlugin,
+} from './plugin.interface';

--- a/backend/src/modules/plugins/interfaces/plugin.interface.ts
+++ b/backend/src/modules/plugins/interfaces/plugin.interface.ts
@@ -1,0 +1,44 @@
+/**
+ * Plugin manifest format - describes a plugin and its tools.
+ */
+export interface PluginManifest {
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  homepage?: string;
+  icon?: string;
+  tools: PluginToolDefinition[];
+}
+
+export interface PluginToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, any>; // JSON Schema
+  apiEndpoint: string; // URL the plugin tool is hosted at
+}
+
+/**
+ * Plugin record from the database.
+ */
+export interface Plugin {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  manifest: PluginManifest;
+  is_active: boolean;
+  install_count: number;
+  created_at: Date;
+}
+
+/**
+ * User-plugin association.
+ */
+export interface UserPlugin {
+  id: string;
+  user_id: string;
+  plugin_id: string;
+  enabled_at: Date;
+}

--- a/backend/src/modules/plugins/plugin-registry.service.ts
+++ b/backend/src/modules/plugins/plugin-registry.service.ts
@@ -1,0 +1,268 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import axios from 'axios';
+import { DatabaseService } from '../database/database.service';
+import { Plugin, UserPlugin, PluginManifest } from './interfaces';
+import { PluginFilterDto } from './dto';
+
+@Injectable()
+export class PluginRegistryService implements OnModuleInit {
+  private readonly logger = new Logger(PluginRegistryService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.ensureTables();
+  }
+
+  /**
+   * Create the plugins and user_plugins tables if they do not exist.
+   */
+  private async ensureTables(): Promise<void> {
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS plugins (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name VARCHAR(255) UNIQUE NOT NULL,
+        version VARCHAR(50) NOT NULL,
+        description TEXT,
+        author VARCHAR(255),
+        manifest JSONB NOT NULL,
+        is_active BOOLEAN DEFAULT true,
+        install_count INTEGER DEFAULT 0,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      );
+    `);
+
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS user_plugins (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL,
+        plugin_id UUID NOT NULL REFERENCES plugins(id) ON DELETE CASCADE,
+        enabled_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        UNIQUE(user_id, plugin_id)
+      );
+    `);
+
+    this.logger.log('Plugin tables ensured');
+  }
+
+  /**
+   * Register a new plugin with its manifest.
+   */
+  async registerPlugin(manifest: PluginManifest): Promise<Plugin> {
+    if (!manifest.name || !manifest.version || !manifest.tools || manifest.tools.length === 0) {
+      throw new BadRequestException(
+        'Plugin manifest must include name, version, and at least one tool',
+      );
+    }
+
+    // Check for duplicate
+    const existing = await this.db.findOne<Plugin>('plugins', { name: manifest.name });
+    if (existing) {
+      throw new ConflictException(`Plugin "${manifest.name}" already exists. Update not supported yet.`);
+    }
+
+    const plugin = await this.db.insert<Plugin>('plugins', {
+      name: manifest.name,
+      version: manifest.version,
+      description: manifest.description || '',
+      author: manifest.author || '',
+      manifest: JSON.stringify(manifest),
+      is_active: true,
+      install_count: 0,
+      created_at: new Date(),
+    });
+
+    return this.transformPlugin(plugin);
+  }
+
+  /**
+   * List registered plugins with optional filtering.
+   */
+  async listPlugins(filters?: PluginFilterDto): Promise<Plugin[]> {
+    const conditions: Record<string, any> = {};
+    if (filters?.is_active !== undefined) {
+      conditions.is_active = filters.is_active;
+    }
+
+    let plugins: Plugin[];
+
+    if (filters?.search) {
+      // Use raw query for ILIKE search
+      const result = await this.db.query<Plugin>(
+        `SELECT * FROM plugins
+         WHERE (name ILIKE $1 OR description ILIKE $1)
+         ${filters.is_active !== undefined ? 'AND is_active = $2' : ''}
+         ORDER BY install_count DESC, created_at DESC
+         LIMIT $${filters.is_active !== undefined ? '3' : '2'}
+         OFFSET $${filters.is_active !== undefined ? '4' : '3'}`,
+        filters.is_active !== undefined
+          ? [`%${filters.search}%`, filters.is_active, filters.limit || 50, filters.offset || 0]
+          : [`%${filters.search}%`, filters.limit || 50, filters.offset || 0],
+      );
+      plugins = result.rows;
+    } else {
+      plugins = await this.db.findMany<Plugin>('plugins', conditions, {
+        orderBy: 'created_at',
+        order: 'DESC',
+        limit: filters?.limit || 50,
+        offset: filters?.offset || 0,
+      });
+    }
+
+    return plugins.map((p) => this.transformPlugin(p));
+  }
+
+  /**
+   * Get a single plugin by ID.
+   */
+  async getPlugin(pluginId: string): Promise<Plugin> {
+    const plugin = await this.db.findOne<Plugin>('plugins', { id: pluginId });
+    if (!plugin) {
+      throw new NotFoundException('Plugin not found');
+    }
+    return this.transformPlugin(plugin);
+  }
+
+  /**
+   * Enable a plugin for a user.
+   */
+  async enablePlugin(pluginId: string, userId: string): Promise<UserPlugin> {
+    // Verify plugin exists
+    await this.getPlugin(pluginId);
+
+    // Check if already enabled
+    const existing = await this.db.findOne<UserPlugin>('user_plugins', {
+      user_id: userId,
+      plugin_id: pluginId,
+    });
+    if (existing) {
+      return existing;
+    }
+
+    const userPlugin = await this.db.insert<UserPlugin>('user_plugins', {
+      user_id: userId,
+      plugin_id: pluginId,
+      enabled_at: new Date(),
+    });
+
+    // Increment install count
+    await this.db.query(
+      'UPDATE plugins SET install_count = install_count + 1 WHERE id = $1',
+      [pluginId],
+    );
+
+    return userPlugin;
+  }
+
+  /**
+   * Disable a plugin for a user.
+   */
+  async disablePlugin(pluginId: string, userId: string): Promise<void> {
+    const existing = await this.db.findOne<UserPlugin>('user_plugins', {
+      user_id: userId,
+      plugin_id: pluginId,
+    });
+    if (!existing) {
+      throw new NotFoundException('Plugin is not enabled for this user');
+    }
+
+    await this.db.query(
+      'DELETE FROM user_plugins WHERE user_id = $1 AND plugin_id = $2',
+      [userId, pluginId],
+    );
+
+    // Decrement install count (floor at 0)
+    await this.db.query(
+      'UPDATE plugins SET install_count = GREATEST(install_count - 1, 0) WHERE id = $1',
+      [pluginId],
+    );
+  }
+
+  /**
+   * Execute a plugin tool by calling its HTTP endpoint.
+   */
+  async executePluginTool(
+    pluginId: string,
+    toolName: string,
+    input: Record<string, any>,
+  ): Promise<any> {
+    const plugin = await this.getPlugin(pluginId);
+    const manifest = plugin.manifest;
+
+    const tool = manifest.tools.find((t) => t.name === toolName);
+    if (!tool) {
+      throw new NotFoundException(
+        `Tool "${toolName}" not found in plugin "${manifest.name}"`,
+      );
+    }
+
+    try {
+      const response = await axios.post(tool.apiEndpoint, input, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 30000,
+      });
+      return response.data;
+    } catch (error: any) {
+      this.logger.error(
+        `Plugin tool execution failed: ${manifest.name}/${toolName}: ${error.message}`,
+      );
+      throw new BadRequestException(
+        `Plugin tool execution failed: ${error.message}`,
+      );
+    }
+  }
+
+  /**
+   * Get all plugin tools enabled for a specific user.
+   * Used by the chat pipeline to include plugin tools in AI context.
+   */
+  async getUserPluginTools(
+    userId: string,
+  ): Promise<Array<{ pluginId: string; pluginName: string; toolName: string; description: string }>> {
+    const result = await this.db.query<any>(
+      `SELECT p.id as plugin_id, p.name as plugin_name, p.manifest
+       FROM user_plugins up
+       JOIN plugins p ON p.id = up.plugin_id
+       WHERE up.user_id = $1 AND p.is_active = true`,
+      [userId],
+    );
+
+    const tools: Array<{ pluginId: string; pluginName: string; toolName: string; description: string }> = [];
+
+    for (const row of result.rows) {
+      const manifest: PluginManifest =
+        typeof row.manifest === 'string' ? JSON.parse(row.manifest) : row.manifest;
+
+      for (const tool of manifest.tools) {
+        tools.push({
+          pluginId: row.plugin_id,
+          pluginName: row.plugin_name,
+          toolName: tool.name,
+          description: tool.description,
+        });
+      }
+    }
+
+    return tools;
+  }
+
+  /**
+   * Transform a plugin row, parsing JSONB manifest if needed.
+   */
+  private transformPlugin(plugin: Plugin): Plugin {
+    return {
+      ...plugin,
+      manifest:
+        typeof plugin.manifest === 'string'
+          ? JSON.parse(plugin.manifest)
+          : plugin.manifest,
+    };
+  }
+}

--- a/backend/src/modules/plugins/plugins.controller.ts
+++ b/backend/src/modules/plugins/plugins.controller.ts
@@ -1,0 +1,96 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginFilterDto } from './dto';
+
+@Controller('api/v1/plugins')
+export class PluginsController {
+  constructor(private readonly pluginRegistry: PluginRegistryService) {}
+
+  /**
+   * POST /api/v1/plugins - Register a plugin (admin only for now, guarded by auth)
+   */
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async registerPlugin(
+    @Body() body: { manifest: any },
+  ) {
+    return this.pluginRegistry.registerPlugin(body.manifest);
+  }
+
+  /**
+   * GET /api/v1/plugins - List available plugins (public)
+   */
+  @Get()
+  async listPlugins(
+    @Query('search') search?: string,
+    @Query('is_active') isActive?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    const filters: PluginFilterDto = {};
+    if (search) filters.search = search;
+    if (isActive !== undefined) filters.is_active = isActive === 'true';
+    if (limit) filters.limit = parseInt(limit, 10);
+    if (offset) filters.offset = parseInt(offset, 10);
+
+    return this.pluginRegistry.listPlugins(filters);
+  }
+
+  /**
+   * GET /api/v1/plugins/:id - Plugin details (public)
+   */
+  @Get(':id')
+  async getPlugin(@Param('id') id: string) {
+    return this.pluginRegistry.getPlugin(id);
+  }
+
+  /**
+   * POST /api/v1/plugins/:id/enable - Enable a plugin for the authenticated user
+   */
+  @Post(':id/enable')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async enablePlugin(@Param('id') id: string, @Req() req: any) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    return this.pluginRegistry.enablePlugin(id, userId);
+  }
+
+  /**
+   * POST /api/v1/plugins/:id/disable - Disable a plugin for the authenticated user
+   */
+  @Post(':id/disable')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async disablePlugin(@Param('id') id: string, @Req() req: any) {
+    const userId = req.user.userId || req.user.id || req.user.sub;
+    await this.pluginRegistry.disablePlugin(id, userId);
+    return { success: true };
+  }
+
+  /**
+   * POST /api/v1/plugins/:id/tools/:toolName/execute - Execute a plugin tool
+   */
+  @Post(':id/tools/:toolName/execute')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async executePluginTool(
+    @Param('id') id: string,
+    @Param('toolName') toolName: string,
+    @Body() input: Record<string, any>,
+  ) {
+    return this.pluginRegistry.executePluginTool(id, toolName, input);
+  }
+}

--- a/backend/src/modules/plugins/plugins.module.ts
+++ b/backend/src/modules/plugins/plugins.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { AuthModule } from '../auth/auth.module';
+import { PluginRegistryService } from './plugin-registry.service';
+import { PluginsController } from './plugins.controller';
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [PluginsController],
+  providers: [PluginRegistryService],
+  exports: [PluginRegistryService],
+})
+export class PluginsModule {}


### PR DESCRIPTION
## Summary
- Adds `collaboration` module enabling real-time multi-user sessions for tool instances (Kanban boards, timelines, expense trackers)
- Users create sessions with shareable 6-character codes, join/leave with participant tracking
- WebSocket gateway handles `collab:join`, `collab:leave`, `collab:state-update`, and `collab:cursor-move` events
- Session state is persisted in `collab_sessions` (JSONB) with merge-on-update semantics

## Endpoints
- `POST /api/v1/collab/sessions` — create session (returns session code)
- `POST /api/v1/collab/sessions/join` — join via code
- `GET /api/v1/collab/sessions/:id` — session details + participants
- `DELETE /api/v1/collab/sessions/:id/leave` — leave session

## WebSocket Events
- `collab:join` / `collab:leave` — room management
- `collab:state-update` — broadcast state changes
- `collab:cursor-move` — cursor awareness
- `collab:participants` — participant list updates

## Test plan
- [ ] Verify `tsc --noEmit` passes with 0 errors
- [ ] Create a session, verify 6-char code is generated
- [ ] Join a session with code, verify participant list updates
- [ ] Connect via WebSocket, send state update, verify broadcast to other participants
- [ ] Leave session, verify participant is marked with left_at
- [ ] Creator leaving deactivates the session

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)